### PR TITLE
Fix failing build by removing bin/release

### DIFF
--- a/bin/release
+++ b/bin/release
@@ -1,2 +1,0 @@
-#!/bin/sh
-echo "release"


### PR DESCRIPTION
Builds fail, because `bin/release` doesn't emit valid yaml.

`bin/release` is useless, since addons and default_process_types are not needed for this buildpack.
