### PR TITLE
Resolve $HOME in profile.d at runtime rather than during the build

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -5,7 +5,8 @@ INSTALL_DIR=$BUILD_DIR/vendor/poppler
 
 ENVSCRIPT=$BUILD_DIR/.profile.d/poppler.sh
 
-POPPLER_DIR=${HOME}/vendor/poppler
+# Single quotes since we want $HOME to be resolved at runtime, not build time.
+POPPLER_DIR='${HOME}/vendor/poppler'
 
 echo "Untarring poppler.tar.gz into ${INSTALL_DIR}"
 


### PR DESCRIPTION
Previously the value for `$HOME` was resolved at build time, meaning its actual value during the build is hardcoded in the `.profile.d/` script, rather than just the variable name.

Whilst the value for `$HOME` is currently the same at both build-time and run-time (both `/app`), the build-time value (only) is due to change in the future to a path under `/tmp`.

By using single quotes, the variable `$HOME` is now resolved at runtime, making the buildpack compatible with this future change.